### PR TITLE
generate the correct repo CRs

### DIFF
--- a/templates/http/overlays/development/gitops-repository.yaml
+++ b/templates/http/overlays/development/gitops-repository.yaml
@@ -1,0 +1,6 @@
+apiVersion: "pipelinesascode.tekton.dev/v1alpha1"
+kind: Repository
+metadata:
+  name: gitops-repository
+spec:
+  url: ${{ values.repoURL }}

--- a/templates/http/overlays/development/kustomization.yaml
+++ b/templates/http/overlays/development/kustomization.yaml
@@ -3,4 +3,6 @@ kind: Kustomization
 patchesStrategicMerge:
 - deployment-patch.yaml
 resources:
-- ../../base
+- ../../base 
+- gitops-repository.yaml
+- source-repository.yaml

--- a/templates/http/overlays/development/source-repository.yaml
+++ b/templates/http/overlays/development/source-repository.yaml
@@ -1,0 +1,6 @@
+apiVersion: "pipelinesascode.tekton.dev/v1alpha1"
+kind: Repository
+metadata:
+  name: source-repository
+spec:
+  url: ${{ values.srcRepoURL }}


### PR DESCRIPTION
Move the tekton CRs into the dev overlay and include them to auto-install them
It only be installed in the dev namespace, if we add a prod namespace, it should not be enabled for tekton
