### PR TITLE
Environments and App of Apps

### DIFF
--- a/templates/app-of-apps/application-dev.yaml
+++ b/templates/app-of-apps/application-dev.yaml
@@ -1,0 +1,25 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: {{values.name}}-development
+  namespace: openshift-gitops 
+  finalizers: ["resources-finalizer.argocd.argoproj.io"] 
+spec:
+  project: default
+  source:
+    path: {{values.argoComponentOverlays}}/development
+    repoURL: {{values.repoURL}}
+    targetRevision: main
+  destination:
+    namespace: {{values.namespace}}-development
+    server: https://kubernetes.default.svc
+  syncPolicy:
+    managedNamespaceMetadata:
+      labels: 
+        argocd.argoproj.io/managed-by: openshift-gitops
+    automated: 
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - PruneLast=true

--- a/templates/app-of-apps/application-prod.yaml
+++ b/templates/app-of-apps/application-prod.yaml
@@ -1,0 +1,25 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: {{values.name}}-prod
+  namespace: openshift-gitops 
+  finalizers: ["resources-finalizer.argocd.argoproj.io"] 
+spec:
+  project: default
+  source:
+    path: {{values.argoComponentOverlays}}/prod
+    repoURL: {{values.repoURL}}
+    targetRevision: main
+  destination:
+    namespace: {{values.namespace}}-prod
+    server: https://kubernetes.default.svc
+  syncPolicy:
+    managedNamespaceMetadata:
+      labels: 
+        argocd.argoproj.io/managed-by: openshift-gitops
+    automated: 
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - PruneLast=true

--- a/templates/app-of-apps/application-stage.yaml
+++ b/templates/app-of-apps/application-stage.yaml
@@ -1,0 +1,26 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: {{values.name}}-stage
+  namespace: openshift-gitops 
+  finalizers: ["resources-finalizer.argocd.argoproj.io"] 
+spec:
+  project: default
+  source:
+    path: {{values.argoComponentOverlays}}/stage
+    repoURL: {{values.repoURL}}
+    targetRevision: main
+  destination:
+    namespace: {{values.namespace}}-stage
+    server: https://kubernetes.default.svc
+  syncPolicy:
+    managedNamespaceMetadata:
+      labels: 
+        argocd.argoproj.io/managed-by: openshift-gitops
+    automated: 
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - PruneLast=true
+

--- a/templates/app-of-apps/kustomization.yaml
+++ b/templates/app-of-apps/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+commonLabels:         
+  rhtap/gitops: {{ values.name }} 
+  janus-idp.io/tekton: {{ values.name }}
+  backstage.io/kubernetes-id: {{ values.name }}
+  backstage.io/kubernetes-namespace: {{ values.namespace }} 
+  app.kubernetes.io/part-of: {{ values.name }}
+resources: 
+- application-dev.yaml 
+- application-stage.yaml 
+- application-prod.yaml  

--- a/templates/http/overlays/prod/deployment-patch.yaml
+++ b/templates/http/overlays/prod/deployment-patch.yaml
@@ -1,0 +1,16 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:   
+  annotations:  
+    tad.gitops.set/image: ".spec.template.spec.containers[0].image"
+    tad.gitops.get/image: ".spec.template.spec.containers[0].image"
+    tad.gitops.set/replicas: ".spec.replicas"
+    tad.gitops.get/replicas: ".spec.replicas" 
+  name: {{values.name}}
+spec:
+  replicas: 1 
+  template: 
+    spec:
+      containers:
+      - image: {{values.image}}
+        name: container-image  

--- a/templates/http/overlays/prod/kustomization.yaml
+++ b/templates/http/overlays/prod/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+patchesStrategicMerge:
+- deployment-patch.yaml
+resources:
+- ../../base  

--- a/templates/http/overlays/stage/deployment-patch.yaml
+++ b/templates/http/overlays/stage/deployment-patch.yaml
@@ -1,0 +1,16 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:   
+  annotations:  
+    tad.gitops.set/image: ".spec.template.spec.containers[0].image"
+    tad.gitops.get/image: ".spec.template.spec.containers[0].image"
+    tad.gitops.set/replicas: ".spec.replicas"
+    tad.gitops.get/replicas: ".spec.replicas" 
+  name: {{values.name}}
+spec:
+  replicas: 1 
+  template: 
+    spec:
+      containers:
+      - image: {{values.image}}
+        name: container-image  

--- a/templates/http/overlays/stage/kustomization.yaml
+++ b/templates/http/overlays/stage/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+patchesStrategicMerge:
+- deployment-patch.yaml
+resources:
+- ../../base  


### PR DESCRIPTION
Added new environment overlays intended to work with dev,stage,prod
This change is compatible with tssc-sample-templates import . Once merged, tssc-sample-templates can import app-of-apps and use that to create the app, which also creates the namespaces

- add new overlays (stage and prod)
- add app-of-apps for dev,stage,prod