### PR TITLE
add isTekton check for repo cr in gitops 

### DIFF
--- a/templates/http/overlays/development/kustomization.yaml
+++ b/templates/http/overlays/development/kustomization.yaml
@@ -4,5 +4,7 @@ patchesStrategicMerge:
 - deployment-patch.yaml
 resources:
 - ../../base 
+{%- if values.isTekton %}
 - gitops-repository.yaml
 - source-repository.yaml
+{%- endif %}


### PR DESCRIPTION

This change will ensure that Tekton is only enabled if/when the template user picks tekton. 
