### PR TITLE
feat: use imagePullSecrets

### DIFF
--- a/templates/http/base/deployment.yaml
+++ b/templates/http/base/deployment.yaml
@@ -49,4 +49,5 @@ spec:
         env:
         - name: GIT_REPO
           value: {{values.repoURL}}
-
+      imagePullSecrets:
+        - name: rhtap-image-registry-auth


### PR DESCRIPTION
This simplifies the namespaces configuration on the cluster, and guarantees that the images can be pulled if the PE customizes the templates to use a ServiceAccount other than `default`.

cf RHTAP-4555